### PR TITLE
Extend HDFS plugin to support Java/JNI 

### DIFF
--- a/hdfs.mk
+++ b/hdfs.mk
@@ -2,3 +2,6 @@ hdfs_SOURCES = env_hdfs.cc env_hdfs_impl.cc
 hdfs_HEADERS = env_hdfs.h env_hdfs_impl.h
 hdfs_CXXFLAGS = -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I${HADOOP_HOME}/include
 hdfs_LDFLAGS = -lhdfs -u hdfs_reg -L${JAVA_HOME}/jre/lib/amd64 -L${HADOOP_HOME}/lib/native -L${JAVA_HOME}/jre/lib/amd64/server -ldl -lverify -ljava -ljvm
+hdfs_JAVA_NATIVE_SOURCES = java/rocksjni/env_hdfs.cc
+hdfs_NATIVE_JAVA_CLASSES = org.rocksdb.HdfsEnv
+hdfs_JAVA_TESTS = org.rocksdb.HdfsEnvTest

--- a/hdfs.mk
+++ b/hdfs.mk
@@ -2,6 +2,6 @@ hdfs_SOURCES = env_hdfs.cc env_hdfs_impl.cc
 hdfs_HEADERS = env_hdfs.h env_hdfs_impl.h
 hdfs_CXXFLAGS = -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I${HADOOP_HOME}/include
 hdfs_LDFLAGS = -lhdfs -u hdfs_reg -L${JAVA_HOME}/jre/lib/amd64 -L${HADOOP_HOME}/lib/native -L${JAVA_HOME}/jre/lib/amd64/server -ldl -lverify -ljava -ljvm
-hdfs_JAVA_NATIVE_SOURCES = java/rocksjni/env_hdfs.cc
+hdfs_JNI_NATIVE_SOURCES = java/rocksjni/env_hdfs.cc
 hdfs_NATIVE_JAVA_CLASSES = org.rocksdb.HdfsEnv
 hdfs_JAVA_TESTS = org.rocksdb.HdfsEnvTest

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "portal.h"
+#include "env_hdfs.h"
 #include "rocksdb/env.h"
 #include "include/org_rocksdb_Env.h"
 #include "include/org_rocksdb_HdfsEnv.h"

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -17,6 +17,13 @@
 #include "include/org_rocksdb_RocksMemEnv.h"
 #include "include/org_rocksdb_TimedEnv.h"
 
+namespace ROCKSDB_NAMESPACE
+{
+    // Returns a new environment that is used for HDFS environment.
+    // This is a factory method for HdfsEnv declared in hdfs/env_hdfs.h
+    Status NewHdfsEnv(Env **hdfs_env, const std::string &fsname);
+}
+
 /*
  * Class:     org_rocksdb_HdfsEnv
  * Method:    createHdfsEnv
@@ -45,15 +52,15 @@ jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
     return reinterpret_cast<jlong>(hdfs_env);
 }
 
-/*
- * Class:     org_rocksdb_HdfsEnv
- * Method:    disposeInternal
- * Signature: (J)V
- */
-void Java_org_rocksdb_HdfsEnv_disposeInternal(
-    JNIEnv *, jobject, jlong jhandle)
-{
-    auto *e = reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(jhandle);
-    assert(e != nullptr);
-    delete e;
-}
+    /*
+     * Class:     org_rocksdb_HdfsEnv
+     * Method:    disposeInternal
+     * Signature: (J)V
+     */
+    void Java_org_rocksdb_HdfsEnv_disposeInternal(
+        JNIEnv *, jobject, jlong jhandle)
+    {
+        auto *e = reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(jhandle);
+        assert(e != nullptr);
+        delete e;
+    }

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -17,13 +17,6 @@
 #include "include/org_rocksdb_RocksMemEnv.h"
 #include "include/org_rocksdb_TimedEnv.h"
 
-namespace ROCKSDB_NAMESPACE
-{
-    // Returns a new environment that is used for HDFS environment.
-    // This is a factory method for HdfsEnv declared in hdfs/env_hdfs.h
-    Status NewHdfsEnv(Env **hdfs_env, const std::string &fsname);
-}
-
 /*
  * Class:     org_rocksdb_HdfsEnv
  * Method:    createHdfsEnv
@@ -40,16 +33,15 @@ jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
         // exception occurred
         return 0;
     }
-    ROCKSDB_NAMESPACE::Env *hdfs_env;
-    ROCKSDB_NAMESPACE::Status s =
-        ROCKSDB_NAMESPACE::NewHdfsEnv(&hdfs_env, fsname);
-    if (!s.ok())
+    std::unique_ptr<ROCKSDB_NAMESPACE::Env> hdfs_env = ROCKSDB_NAMESPACE::NewHdfsEnv(&hdfs_env, fsname);
+    if (!hdfs_env)
     {
         // error occurred
         ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
         return 0;
     }
-    return reinterpret_cast<jlong>(hdfs_env);
+    auto ptr_as_handle = hdfs_env.release();
+    return reinterpret_cast<jlong>(ptr_as_handle);
 }
 
     /*

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ and enables
+// calling c++ ROCKSDB_NAMESPACE::Env methods from Java side.
+
+#include <jni.h>
+#include <vector>
+
+#include "portal.h"
+#include "rocksdb/env.h"
+#include "include/org_rocksdb_Env.h"
+#include "include/org_rocksdb_HdfsEnv.h"
+#include "include/org_rocksdb_RocksEnv.h"
+#include "include/org_rocksdb_RocksMemEnv.h"
+#include "include/org_rocksdb_TimedEnv.h"
+
+/*
+ * Class:     org_rocksdb_HdfsEnv
+ * Method:    createHdfsEnv
+ * Signature: (Ljava/lang/String;)J
+ */
+jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
+    JNIEnv *env, jclass, jstring jfsname)
+{
+    jboolean has_exception = JNI_FALSE;
+    auto fsname =
+        ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jfsname, &has_exception);
+    if (has_exception == JNI_TRUE)
+    {
+        // exception occurred
+        return 0;
+    }
+    ROCKSDB_NAMESPACE::Env *hdfs_env;
+    ROCKSDB_NAMESPACE::Status s =
+        ROCKSDB_NAMESPACE::NewHdfsEnv(&hdfs_env, fsname);
+    if (!s.ok())
+    {
+        // error occurred
+        ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+        return 0;
+    }
+    return reinterpret_cast<jlong>(hdfs_env);
+}
+
+/*
+ * Class:     org_rocksdb_HdfsEnv
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_HdfsEnv_disposeInternal(
+    JNIEnv *, jobject, jlong jhandle)
+{
+    auto *e = reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(jhandle);
+    assert(e != nullptr);
+    delete e;
+}

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -45,15 +45,15 @@ jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
     return reinterpret_cast<jlong>(ptr_as_handle);
 }
 
-    /*
-     * Class:     org_rocksdb_HdfsEnv
-     * Method:    disposeInternal
-     * Signature: (J)V
-     */
-    void Java_org_rocksdb_HdfsEnv_disposeInternal(
-        JNIEnv *, jobject, jlong jhandle)
-    {
-        auto *e = reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(jhandle);
-        assert(e != nullptr);
-        delete e;
-    }
+/*
+    * Class:     org_rocksdb_HdfsEnv
+    * Method:    disposeInternal
+    * Signature: (J)V
+    */
+void Java_org_rocksdb_HdfsEnv_disposeInternal(
+    JNIEnv *, jobject, jlong jhandle)
+{
+    auto *e = reinterpret_cast<ROCKSDB_NAMESPACE::Env *>(jhandle);
+    assert(e != nullptr);
+    delete e;
+}

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -33,7 +33,7 @@ jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
         // exception occurred
         return 0;
     }
-    std::unique_ptr<ROCKSDB_NAMESPACE::Env> hdfs_env = ROCKSDB_NAMESPACE::NewHdfsEnv(&hdfs_env, fsname);
+    std::unique_ptr<ROCKSDB_NAMESPACE::Env> hdfs_env = ROCKSDB_NAMESPACE::NewHdfsEnv(fsname);
     if (!hdfs_env)
     {
         // error occurred

--- a/java/rocksjni/env_hdfs.cc
+++ b/java/rocksjni/env_hdfs.cc
@@ -37,7 +37,7 @@ jlong Java_org_rocksdb_HdfsEnv_createHdfsEnv(
     if (!hdfs_env)
     {
         // error occurred
-        ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+        ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, "Unable to create HDFS environment");
         return 0;
     }
     auto ptr_as_handle = hdfs_env.release();

--- a/java/src/main/java/org/rocksdb/HdfsEnv.java
+++ b/java/src/main/java/org/rocksdb/HdfsEnv.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * HDFS environment.
+ */
+public class HdfsEnv extends Env {
+
+  /**
+   <p>Creates a new environment that is used for HDFS environment.</p>
+   *
+   * <p>The caller must delete the result when it is
+   * no longer needed.</p>
+   *
+   * @param fsName the HDFS as a string in the form "hdfs://hostname:port/"
+   */
+  public HdfsEnv(final String fsName) {
+    super(createHdfsEnv(fsName));
+  }
+
+  private static native long createHdfsEnv(final String fsName);
+  @Override protected final native void disposeInternal(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/HdfsEnvTest.java
+++ b/java/src/test/java/org/rocksdb/HdfsEnvTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class HdfsEnvTest {
+
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule
+  public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
+  @Test(expected = RocksDBException.class)
+  public void construct() throws RocksDBException {
+    try (final Env env = new HdfsEnv("hdfs://localhost:5000")) {
+      // no-op
+    }
+  }
+
+  // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
+  @Test(expected = RocksDBException.class)
+  public void construct_integration() throws RocksDBException {
+    try (final Env env = new HdfsEnv("hdfs://localhost:5000");
+         final Options options = new Options()
+             .setCreateIfMissing(true)
+             .setEnv(env);
+    ) {
+      try (final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getPath())) {
+        db.put("key1".getBytes(UTF_8), "value1".getBytes(UTF_8));
+      }
+    }
+  }
+}

--- a/java/src/test/java/org/rocksdb/HdfsEnvTest.java
+++ b/java/src/test/java/org/rocksdb/HdfsEnvTest.java
@@ -18,19 +18,27 @@ public class HdfsEnvTest {
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
       new RocksNativeLibraryResource();
 
-  @Rule
-  public TemporaryFolder dbFolder = new TemporaryFolder();
+  // @Rule
+  // public TemporaryFolder dbFolder = new TemporaryFolder();
 
-  // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
-  @Test // (expected = RocksDBException.class)
+  /**
+   * Connect to a running hdfs
+   * 
+   * @throws RocksDBException
+   */
+  @Test
   public void construct() throws RocksDBException {
     try (final Env env = new HdfsEnv("hdfs://localhost:5000")) {
       // no-op
     }
   }
 
-  // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
-  @Test // (expected = RocksDBException.class)
+  /**
+   * Connect to a running hdfs and do a simple put
+   * 
+   * @throws RocksDBException
+   */
+  // @Test
   public void construct_integration() throws RocksDBException {
     try (final Env env = new HdfsEnv("hdfs://localhost:5000");
          final Options options = new Options()

--- a/java/src/test/java/org/rocksdb/HdfsEnvTest.java
+++ b/java/src/test/java/org/rocksdb/HdfsEnvTest.java
@@ -18,8 +18,8 @@ public class HdfsEnvTest {
   public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
       new RocksNativeLibraryResource();
 
-  // @Rule
-  // public TemporaryFolder dbFolder = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder dbFolder = new TemporaryFolder();
 
   /**
    * Connect to a running hdfs

--- a/java/src/test/java/org/rocksdb/HdfsEnvTest.java
+++ b/java/src/test/java/org/rocksdb/HdfsEnvTest.java
@@ -38,7 +38,7 @@ public class HdfsEnvTest {
    * 
    * @throws RocksDBException
    */
-  // @Test
+  @Test
   public void construct_integration() throws RocksDBException {
     try (final Env env = new HdfsEnv("hdfs://localhost:5000");
          final Options options = new Options()

--- a/java/src/test/java/org/rocksdb/HdfsEnvTest.java
+++ b/java/src/test/java/org/rocksdb/HdfsEnvTest.java
@@ -22,7 +22,7 @@ public class HdfsEnvTest {
   public TemporaryFolder dbFolder = new TemporaryFolder();
 
   // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
-  @Test(expected = RocksDBException.class)
+  @Test // (expected = RocksDBException.class)
   public void construct() throws RocksDBException {
     try (final Env env = new HdfsEnv("hdfs://localhost:5000")) {
       // no-op
@@ -30,7 +30,7 @@ public class HdfsEnvTest {
   }
 
   // expect org.rocksdb.RocksDBException: Not compiled with hdfs support
-  @Test(expected = RocksDBException.class)
+  @Test // (expected = RocksDBException.class)
   public void construct_integration() throws RocksDBException {
     try (final Env env = new HdfsEnv("hdfs://localhost:5000");
          final Options options = new Options()


### PR DESCRIPTION
Adds configuration for the Java part of the HDFS plugin consistent with the parallel PR https://github.com/riversand963/rocksdb/pull/4

This PR transfers the former JNI code which was part of the core of RocksDB, and adds it to the hdfs plugin so that the plugin also builds the Java API support (and JNI) for the hdfs filesystem option to RocksDB when the plugin is included.

STATUS - This plugin builds in an ubuntu development environment with a configured hdfs installed, and sucessfully runs the tests which it contributes (`org.rocksdb.HdfsEnvTest`) but the JVM reports a SEGV after completion of the tests; this seems to happen independent of whether we ever `close()` the HdfsEnv (and certainly, not in the direct path of the `close()`). We are unclear if there is a problem in the C++ level RocksDB HDFS code, how HDFS is used, or the Java/JNI code, but we think it best in the meantime to contribute this code to the experimental branch.